### PR TITLE
Add array_indexof method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # POSIX-compliant implementation of arrays in shell
 
-It is zero-based and uses "\n" as delimiter, do not mess with it (unless you know what you're doing, which you're probably not ;) ).
+It is zero-based and uses "\n" as delimiter, do not mess with it (unless you know what you're doing, which you probably don't ;) ).
 If you have suggestions for improvements feel free to send a pull request.
 
 # Usage
@@ -40,4 +40,8 @@ $ echo "$A" | while IFS= read element; do echo "$element, "; done
 ross,
 ,
 khan,
+
+# Get the index of the element khan
+$ echo "$A" | array_indexof khan
+3%
 ```

--- a/array
+++ b/array
@@ -12,7 +12,7 @@ array () {
 
 ##
 # Get length of array
-# 
+#
 # Pipe your array in:
 #   echo "$ary" | array_len
 array_len () {
@@ -34,3 +34,17 @@ array_len () {
 array_nth () {
   test "$1" -ge 0 && sed -n $(expr $1 + 1)p | grep .
 }
+
+##
+# Get the first index of an element
+#
+# Exit status:
+#    0  Success.
+#  >=1  Element not found
+#
+# Pipe your array in:
+#   echo "$ary" | array_indexof $element
+array_indexof() {
+  expr -1 + $(sed -n "/^$(echo "$1" | sed -e 's/[]\/$*.^|[]/\\&/g')$/=" | head -n 1 | grep .) 2> /dev/null
+}
+

--- a/test
+++ b/test
@@ -1,0 +1,37 @@
+#! /bin/sh
+
+# Test suite for array
+
+set -e
+
+. "$(pwd)/array"
+
+# test array_indexof
+
+A=$(array ' bob' 'ross' '' 'khan' 'ross' '/\#$^' 'ro')
+
+idx=$(echo "$A" | array_indexof khan)
+[ $idx -eq 3 ] || (>&2 echo "Index of khan: expected 3, got $idx" && exit 1)
+
+if echo "$A" | array_indexof "tim" > /dev/null 2>&1 ; then
+  set +e
+  idx="$(echo "$A" | array_indexof tim)"
+  set -e
+
+  (>&2 echo "Index of tim: expected -1, got $idx" && exit 1)
+fi
+
+idx=$(echo "$A" | array_indexof "")
+[ $idx -eq 2 ] || (>&2 echo "Index of : expected 2, got $idx" && exit 1)
+
+idx=$(echo "$A" | array_indexof ross)
+[ $idx -eq 1 ] || (>&2 echo "Index of ross: expected 1, got $idx" && exit 1)
+
+idx=$(echo "$A" | array_indexof "/\#$^")
+[ $idx -eq 5 ] || (>&2 echo "Index of /\#$^: expected 5, got $idx" && exit 1)
+
+idx=$(echo "$A" | array_indexof ro)
+[ $idx -eq 6 ] || (>&2 echo "Index of ro: expected 6, got $idx" && exit 1)
+
+echo "Tests successful"
+


### PR DESCRIPTION
I was looking for a way to create associate arrays in your script. I was only missing a way to get the index of a particular key in one array and use that to find the value at that index in the other array.  
Not sure if you are interested in the change, but thought I would send it on. I am sure there is also a simpler way to do what I have here.

Thanks,
Andrew
