### PR TITLE
expr evaluating to 0 are "false" so array_indexof returning 0 fails

### DIFF
--- a/array
+++ b/array
@@ -39,12 +39,13 @@ array_nth () {
 # Get the first index of an element
 #
 # Exit status:
-#    0  Success.
-#  >=1  Element not found
+#   0  Success.
+#  >1  Element not found
 #
 # Pipe your array in:
 #   echo "$ary" | array_indexof $element
 array_indexof() {
-  expr -1 + $(sed -n "/^$(echo "$1" | sed -e 's/[]\/$*.^|[]/\\&/g')$/=" | head -n 1 | grep .) 2> /dev/null
+  i=$((-1 + $(sed -n "/^$(echo "$1" | sed -e 's/[]\/$*.^|[]/\\&/g')$/=" | head -n 1 | grep .)))
+  echo $i
 }
 

--- a/test
+++ b/test
@@ -33,5 +33,8 @@ idx=$(echo "$A" | array_indexof "/\#$^")
 idx=$(echo "$A" | array_indexof ro)
 [ $idx -eq 6 ] || (>&2 echo "Index of ro: expected 6, got $idx" && exit 1)
 
+idx=$(echo "$A" | array_indexof " bob")
+[ $idx -eq 0 ] || (>&2 echo "Index of : expected 0, got $idx" && exit 1)
+
 echo "Tests successful"
 


### PR DESCRIPTION
There is a bug in my array_indexof implementation. If the value is at index zero, the expression is 'expr -1 + 1' which results in zero. Reading the man page for expr more closely, exit code is 1 if the expression results in 0, otherwise it is 0.

I am not sure of the most clever way to solve this, but this is my solution.
