### PR TITLE
Support array on solaris

### DIFF
--- a/array
+++ b/array
@@ -1,5 +1,12 @@
 #! /bin/sh
 
+# must use nawk for solaris
+# http://cfajohnson.com/shell/cus-faq-2.html#Q24
+case `uname` in
+  SunOS) arrayawkcmd=nawk ;;
+  *) arrayawkcmd=awk ;;
+esac
+
 ##
 # Definitions:
 # - An array is a newline separated list of array elements.
@@ -10,7 +17,7 @@
 #
 # Turn arguments into an array.
 array () {
-  for i; do
+  for i in "$@" ; do
     echo "$i" | array_element_encode
   done
 }
@@ -22,7 +29,7 @@ array () {
 #   array_append "$A" 'next' 'another'
 array_append () {
   echo "$1" && shift &&
-  for i; do
+  for i in "$@" ; do
     echo "$i" | array_element_encode
   done
 }
@@ -50,7 +57,7 @@ array_len () {
 #   echo "$ary" | array_nth $index
 array_nth () {
   printf '%d' "$1" >/dev/null 2>&1 \
-    && awk -v i=$1 '
+    && "$arrayawkcmd" -v i="$1" '
         BEGIN { code=1 }
         NR == i + 1 { print $0; code=0 }
         END { exit code }
@@ -68,7 +75,7 @@ array_nth () {
 # Pipe your array in:
 #   echo "$ary" | array_indexof "$element"
 array_indexof () {
-  e="$(echo "$1" | array_element_encode)" awk '
+  e="`echo "$1" | array_element_encode`" "$arrayawkcmd" '
     BEGIN { e=ENVIRON["e"] ; i = -1 ; code = 1 }
     i < 0 && e == $0 { i = NR - 1 ; print i ; code = 0 }
     END { exit code }
@@ -91,3 +98,4 @@ array_element_decode() {
   sed -e 's/%0[aA]/\
 /g' -e 's/%25/%/g'
 }
+

--- a/test
+++ b/test
@@ -4,52 +4,59 @@
 
 set -e
 
-. "$(pwd)/array"
+. "`pwd`/array"
 
 # test array_indexof
 
-A=$(array ' bob' 'ross' '' 'khan' 'ross' '/\#$^' 'ro')
+A=`array ' bob' 'ross' '' 'khan' 'ross' '/\#$^' 'ro'`
 
-if ! (idx=$(echo "$A" | array_indexof khan)) && [ "$idx" -eq 3 ]; then
+idx=`echo "$A" | array_indexof khan` || { echo "Index of khan failed" >&2 ; exit 1; }
+if [ "$idx" -ne 3 ] ; then
   echo "Index of khan, expected 3, got $idx" >&2
   exit 1
 fi
 
-if idx=$(echo "$A" | array_indexof "tim") ; then
-  echo "Index of tim should fail, got $idx" >&2
+if echo "$A" | array_indexof "tim" > /dev/null 2>&1 ; then
+  echo "Index of tim should fail, got `echo "$A" | array_indexof "tim"`" >&2
   exit 1
 fi
 
-if ! (idx=$(echo "$A" | array_indexof "") && [ "$idx" -eq 2 ]); then
+idx=`echo "$A" | array_indexof ""` || { echo "Index of failed" >&2 ; exit 1; }
+if [ "$idx" -ne 2 ] ; then
   echo "Index of : expected 2, got $idx" >&2
   exit 1
 fi
 
-if ! (idx=$(echo "$A" | array_indexof ross) && [ "$idx" -eq 1 ]); then
+idx=`echo "$A" | array_indexof ross` || { echo "Index of ross failed" >&2 ; exit 1; }
+if [ "$idx" -ne 1 ] ; then
   echo "Index of ross: expected 1, got $idx" >&2
   exit 1
 fi
 
-if ! (idx=$(echo "$A" | array_indexof "/\#$^") && [ "$idx" -eq 5 ]); then
+idx=`echo "$A" | array_indexof '/\#$^'` || { echo "Index of /\#$^ failed" >&2 ; exit 1; }
+if [ "$idx" -ne 5 ] ; then
   echo "Index of /\#$^: expected 5, got $idx" >&2
   exit 1
 fi
 
-if ! (idx=$(echo "$A" | array_indexof ro) && [ "$idx" -eq 6 ]); then
+idx=`echo "$A" | array_indexof ro` || { echo "Index of ro failed" >&2 ; exit 1; }
+if [ "$idx" -ne 6 ] ; then
   echo "Index of ro: expected 6, got $idx" >&2
   exit 1
 fi
 
-if ! (idx=$(echo "$A" | array_indexof " bob") && [ "$idx" -eq 0 ]); then
+idx=`echo "$A" | array_indexof " bob"` || { echo "Index of  bob failed" >&2 ; exit 1; }
+if [ "$idx" -ne 0 ] ; then
   echo "Index of  bob: expected 0, got $idx" >&2
   exit 1
 fi
 
 # test array_nth
 
-A=$(array ' bob' 'ross' '' 'khan' 'ross' '/\#$^' 'ro')
+A=`array ' bob' 'ross' '' 'khan' 'ross' '/\#$^' 'ro'`
 
-if ! (val=$(echo "$A" | array_nth 2) && [ "$val" = "" ]); then
+val=`echo "$A" | array_nth 2` || { echo "array_nth 2 failed" >&2 ; exit 1; }
+if [ "$val" != "" ] ; then
   echo "array_nth that should return the empty string, didn't." >&2
   exit 1
 fi
@@ -60,7 +67,7 @@ E='look
 ma
 three lines and a %'
 expect_encoded_E='look%0Ama%0Athree lines and a %25'
-really_encoded_E=$(echo "$E" | array_element_encode)
+really_encoded_E=`echo "$E" | array_element_encode`
 
 if [ "$expect_encoded_E" != "$really_encoded_E" ]; then
   echo "array_element_encode doesn't do the right thing" >&2
@@ -69,7 +76,7 @@ if [ "$expect_encoded_E" != "$really_encoded_E" ]; then
   exit 1
 fi
 
-really_decoded_E=$(echo "$really_encoded_E" | array_element_decode)
+really_decoded_E=`echo "$really_encoded_E" | array_element_decode`
 if [ "$E" != "$really_decoded_E" ]; then
   echo "array_element_decode doesn't do the right thing" >&2
   echo "  wanted: $E" >&2
@@ -77,28 +84,38 @@ if [ "$E" != "$really_decoded_E" ]; then
   exit 1
 fi
 
-A1=$(array "$E")
-if [ "$(echo "$A1" | array_nth 0)" != "$E" ]; then
+A1=`array "$E"`
+if [ "`echo "$A1" | array_nth 0`" != "$E" ]; then
   echo "array_nth cannot handle encoded elements" >&2
   exit 1
 fi
 
-if [ "$(echo "$A1" | array_indexof "$E")" -ne 0 ]; then
+if [ "`echo "$A1" | array_indexof "$E"`" -ne 0 ]; then
   echo "array_indexof cannot handle encoded elements" >&2
   exit 1
 fi
 
-# test append
+# test array_append
 
-A=$(array_append "$A" 'next')
+A=`array_append "$A" 'next'`
 
-if ! (idx=$(echo "$A" | array_indexof "next") && [ "$idx" -eq 7 ]); then
+idx=`echo "$A" | array_indexof "next"` || { echo "Index of next failed" >&2 ; exit 1; }
+if [ "$idx" -ne 7 ] ; then
   echo "Index of next: expected 7, got $idx" >&2
   exit 1
 fi
 
-if ! (idx=$(echo "$A" | array_indexof " bob") && [ "$idx" -eq 0 ]); then
+idx=`echo "$A" | array_indexof " bob"` || { echo "Index of  bob failed" >&2 ; exit 1; }
+if [ "$idx" -ne 0 ] ; then
   echo "Index of  bob: expected 0, got $idx" >&2
+  exit 1
+fi
+
+# test array_len
+
+len=`echo "$A" | array_len` || { echo "array_len failed" >&2 ; exit 1; }
+if [ "$len" -ne 8 ] ; then
+  echo "array_len: expected 8, got $len" >&2
   exit 1
 fi
 


### PR DESCRIPTION
/bin/sh on solaris is ancient and does not support $() command
subsitution. Additionally, awk on solaris is oawk (old-awk) and it seems
impossible to find a syntax for passing shell variables with embedded
escapes which works on solaris and on linux and the bsds, so I have
resorted to using a case statement to switch to using nawk on solaris.

When iterating the arguments to a function, /bin/sh on solaris also
requires the explicit 'in "$@"' otherwise we get a syntax error.